### PR TITLE
fix: Profile 조회 시 불필요한 toObject 메서드 제거

### DIFF
--- a/server/src/profile/profile.service.ts
+++ b/server/src/profile/profile.service.ts
@@ -24,7 +24,7 @@ export class ProfileService {
   }
 
   async findByUserId(userId: string): Promise<Profile> {
-    const profile = (await this.profileModel.findOne({ _id: userId })).toObject();
+    const profile = (await this.profileModel.findOne({ _id: userId }));
     if (!profile) {
       throw new NotFoundException('Profile not found');
     }


### PR DESCRIPTION
- ProfileService의 findByUserId 메서드에서 toObject() 호출 제거
  - MongoDB 문서가 이미 객체 형태로 반환되어 추가 변환이 불필요
  - 불필요한 메모리 할당 방지