### PR TITLE
fix: PDF 다운로드 API 경로 수정

### DIFF
--- a/client/src/widgets/resume-detail/ui/ResumeDetail.tsx
+++ b/client/src/widgets/resume-detail/ui/ResumeDetail.tsx
@@ -91,7 +91,7 @@ export default function ResumeDetail({ id }: ResumeDetailProps) {
 
   const handleDownloadPdf = async () => {
     try {
-      const response: Response = await client.get(`/api/resumes/${id}/pdf`);
+      const response: Response = await client.get(`/resumes/${id}/pdf`);
 
       if (!response.ok) throw new Error('PDF 생성에 실패했습니다.');
 


### PR DESCRIPTION
- ResumeDetail 컴포넌트의 PDF 다운로드 API 경로 수정
  - /api/resumes/${id}/pdf → /resumes/${id}/pdf
  - API 기본 경로와 일관성 유지를 위한 수정